### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,10 +65,10 @@ When the bus is on route or heading from the terminal to its first trip, a respo
 }
 ```
 * *tmstmp*: timestamp of the API result
-* *typ*: ?
+* *typ*: A for arrival or D for departure; D is only present on the first stop of a trip
 * *stpnm*: Stop Name
 * *stpid*: Stop ID, corresponds to textmybus and SMART's GTFS file I believe
-* *dstp*: ?
+* *dstp*: Distance remaining to the stop, in feet.
 * *rt*: Route Number
 * *rtdir*: Route Direction
 * *des*: Description (route name; roughly corresponds to what's on the bus's headsign)


### PR DESCRIPTION
Added definitions for `typ` and `dstp`; also, I feel like `tatripid` corresponds to the GTFS as well but it's unproven since I have an outdated file.